### PR TITLE
Update swirldemo.ino

### DIFF
--- a/examples/swirldemo/swirldemo.ino
+++ b/examples/swirldemo/swirldemo.ino
@@ -18,14 +18,11 @@ void setup() {
   Serial.println("IS31 found!");
 }
 
-uint8_t incr =0;
 void loop() {
-   // animate over all the pixels, and set the brightness from the sweep table
-   for (uint8_t x=0; x<16; x++) {
-    for (uint8_t y=0; y<9; y++) {
-      ledmatrix.drawPixel(x, y, sweep[(x+y+incr)%24]);
-    }
-  }
-  incr++;
+  // animate over all the pixels, and set the brightness from the sweep table
+  for (uint8_t incr = 0; incr < 24; incr++)
+    for (uint8_t x = 0; x < 16; x++)
+      for (uint8_t y = 0; y < 9; y++)
+        ledmatrix.drawPixel(x, y, sweep[(x+y+incr)%24]);
   delay(20);
 }


### PR DESCRIPTION
`incr` is a `uint8_t`. Max value is 255.

The animation is 24 pixels long.

After (255+1)/24 = 10.66 loops of the animation, `incr` overflows causing jank in the animation.

The modification prevents this jank in the animation.
