### PR TITLE
defines for normal and high speed. added parameter to begin() function.

### DIFF
--- a/Adafruit_IS31FL3731.cpp
+++ b/Adafruit_IS31FL3731.cpp
@@ -15,8 +15,10 @@ Adafruit_IS31FL3731::Adafruit_IS31FL3731(uint8_t x, uint8_t y) : Adafruit_GFX(x,
 Adafruit_IS31FL3731_Wing::Adafruit_IS31FL3731_Wing(void) : Adafruit_IS31FL3731(15, 7) {
 }
 
-boolean Adafruit_IS31FL3731::begin(uint8_t addr) {
+boolean Adafruit_IS31FL3731::begin(uint8_t addr, uint32_t wirespeed) {
+  
   Wire.begin();
+  Wire.setClock(wirespeed);
 
   _i2caddr = addr;
   _frame = 0;

--- a/Adafruit_IS31FL3731.h
+++ b/Adafruit_IS31FL3731.h
@@ -7,6 +7,9 @@
 
 #define ISSI_ADDR_DEFAULT 0x74
 
+#define ISSI_WIRE_SPEED_DEFAULT 100000
+#define ISSI_WIRE_SPEED_HI 400000
+
 #define ISSI_REG_CONFIG  0x00
 #define ISSI_REG_CONFIG_PICTUREMODE 0x00
 #define ISSI_REG_CONFIG_AUTOPLAYMODE 0x08
@@ -28,7 +31,7 @@
 class Adafruit_IS31FL3731 : public Adafruit_GFX {
  public:
   Adafruit_IS31FL3731(uint8_t x=16, uint8_t y=9); 
-  boolean begin(uint8_t addr = ISSI_ADDR_DEFAULT);
+  boolean begin(uint8_t addr = ISSI_ADDR_DEFAULT, uint32_t wirespeed = ISSI_WIRE_SPEED_DEFAULT);
   void drawPixel(int16_t x, int16_t y, uint16_t color);
   void clear(void);
 

--- a/examples/swirldemo/swirldemo.ino
+++ b/examples/swirldemo/swirldemo.ino
@@ -20,6 +20,14 @@ void setup() {
     while (1);
   }
   Serial.println("IS31 found!");
+
+  /* 
+  if (! ledmatrix.begin(ISSI_ADDR_DEFAULT, ISSI_WIRE_SPEED_HI)) {
+    Serial.println("IS31 not found under given address, or high speed setting not available on your platform.");
+    while (1);
+  }
+  Serial.println("IS31 found! High Speed enabled (faster refresh)");
+  */
 }
 
 void loop() {


### PR DESCRIPTION
Hello there, finally contributing more than just questions... :)

The 16x9 update rate for all LEDs was to little for my project and I searched for ways to improve it. Found that the IC can handle up to 400khz I2S frequency, but the Wire-Library by default initialises at 100khz.

Tested by hardcoding it: made a very visible difference, when updating a lot of LEDs. Adopted the changes into the IS31FL3731 so others can use without hazzle.

Added a little test to the swirldemo example.

Guess all the commonly used UCs can handle that speed. But if not I don't know what would happen...

All the best,
Hans
