### PR TITLE
Set I2C clock to the one used by the IC

### DIFF
--- a/Adafruit_IS31FL3731.cpp
+++ b/Adafruit_IS31FL3731.cpp
@@ -17,7 +17,8 @@ Adafruit_IS31FL3731_Wing::Adafruit_IS31FL3731_Wing(void) : Adafruit_IS31FL3731(1
 
 boolean Adafruit_IS31FL3731::begin(uint8_t addr) {
   Wire.begin();
-
+  Wire.setClock(400000);
+  
   _i2caddr = addr;
   _frame = 0;
 


### PR DESCRIPTION
By default Arduino runs I2C at 100KHz which is well below the 400KHz specified by the chip. Animations are slow and jittery at 100KHz.

I tested this change on a Metro M4.