### PR TITLE
Add ATMega4809 from Arduino Nano Every to list as `Doesn't work`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ ATtiny85 @ 16MHz   |      X       |             |            |
 ATtiny85 @ 8MHz    |      X       |             |            | 
 Intel Curie @ 32MHz |      X       |             |            | 
 STM32F2            |             |             |     X       | 
+ATMega4809         |             |      X      |             |
 
   * ATmega328 @ 16MHz : Arduino UNO, Adafruit Pro Trinket 5V, Adafruit Metro 328, Adafruit Metro Mini
   * ATmega328 @ 12MHz : Adafruit Pro Trinket 3V
@@ -29,5 +30,6 @@ STM32F2            |             |             |     X       |
   * ATSAM21D : Arduino Zero, M0 Pro
   * ATtiny85 @ 16MHz : Adafruit Trinket 5V
   * ATtiny85 @ 8MHz : Adafruit Gemma, Arduino Gemma, Adafruit Trinket 3V
+  * ATMega4809 : Ardunio Nano Every
 
 <!-- END COMPATIBILITY TABLE -->


### PR DESCRIPTION
Does not compile. Possibly the ATMega4809 has different i2c registers? I will try to look into it and send a PR if I get it working.

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
