### PR TITLE
Fix compiler warning on ATMega4809 , update README.md

### DIFF
--- a/Adafruit_IS31FL3731.cpp
+++ b/Adafruit_IS31FL3731.cpp
@@ -179,7 +179,7 @@ uint8_t  Adafruit_IS31FL3731::readRegister8(uint8_t bank, uint8_t reg) {
  Wire.endTransmission();
 
  Wire.beginTransmission(_i2caddr);
- Wire.requestFrom(_i2caddr, (byte)1);
+ Wire.requestFrom(_i2caddr, (size_t)1);
  x = Wire.read();
  Wire.endTransmission();
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ ATSAMD51           |      X       |             |            |
 ATtiny85 @ 16MHz   |      X       |             |            | 
 ATtiny85 @ 8MHz    |      X       |             |            | 
 Intel Curie @ 32MHz |      X       |             |            | 
-STM32F2            |             |             |     X       | 
+STM32F2            |             |             |     X       |
+ATMega4809         |      X       |             |            | 
 
   * ATmega328 @ 16MHz : Arduino UNO, Adafruit Pro Trinket 5V, Adafruit Metro 328, Adafruit Metro Mini
   * ATmega328 @ 12MHz : Adafruit Pro Trinket 3V
@@ -29,5 +30,6 @@ STM32F2            |             |             |     X       |
   * ATSAM21D : Arduino Zero, M0 Pro
   * ATtiny85 @ 16MHz : Adafruit Trinket 5V
   * ATtiny85 @ 8MHz : Adafruit Gemma, Arduino Gemma, Adafruit Trinket 3V
+  * ATMega4809 : Arduino Nano Every
 
 <!-- END COMPATIBILITY TABLE -->


### PR DESCRIPTION
# Overview

This PR allows the library to compile cleanly with both the Ardunio Nano Every board type.

It also updates the `README.md` to show that the Nano Every board has been tested and does work. 

# Details

This library depends on the Arduino Wire library. There are some subtle differences between the Wire library included with the standard `avr` core and the one included in the `megaavr` core used by the new Arduino Nano Every board. 

Specifically, the signatures for the `Wire.requestFrom()` method [were changed](https://github.com/arduino/ArduinoCore-megaavr/commit/667b8d10e04e252736051b906af23aed35e3103a#diff-f1344d8f8dd31c4411770e150a4425fcR60) in a way that causes [the call in the IS31FL3731 library](https://github.com/adafruit/Adafruit_IS31FL3731/blob/master/Adafruit_IS31FL3731.cpp#L182) to be type ambiguous when compiled against the `megaavr` version of the `Wire` library. 

This PR changes the typecast in this call so that is non-ambiguous against both versions of the Wire library.

There are no side effects to this change.  

Tested against an Arduino UNO and an Ardunio Nano Every. 

# Jurisdiction

One could argue that this problem would be better addressed by reconciling the differences between the two Arduino Wire libraries, especially since they are *both* clearly incorrect (all versions of `requestFrom()` should at least return the same or larger type as their `quantity` argument to avoid overflow problems). Unfortunately this would be a bigger can of worms than I am willing to take on right now, so this very quick, effective, and low risk PR will have to do. 

