### PR TITLE
replace boolean type with bool

### DIFF
--- a/Adafruit_IS31FL3731.cpp
+++ b/Adafruit_IS31FL3731.cpp
@@ -227,7 +227,7 @@ void Adafruit_IS31FL3731::selectBank(uint8_t bank) {
     @param sync True to enable, False to disable
 */
 /**************************************************************************/
-void Adafruit_IS31FL3731::audioSync(boolean sync) {
+void Adafruit_IS31FL3731::audioSync(bool sync) {
   if (sync) {
     writeRegister8(ISSI_BANK_FUNCTIONREG, ISSI_REG_AUDIOSYNC, 0x1);
   } else {

--- a/Adafruit_IS31FL3731.h
+++ b/Adafruit_IS31FL3731.h
@@ -33,12 +33,12 @@
 class Adafruit_IS31FL3731 : public Adafruit_GFX {
  public:
   Adafruit_IS31FL3731(uint8_t x=16, uint8_t y=9); 
-  boolean begin(uint8_t addr = ISSI_ADDR_DEFAULT);
+  bool begin(uint8_t addr = ISSI_ADDR_DEFAULT);
   void drawPixel(int16_t x, int16_t y, uint16_t color);
   void clear(void);
 
   void setLEDPWM(uint8_t lednum, uint8_t pwm, uint8_t bank = 0);
-  void audioSync(boolean sync);
+  void audioSync(bool sync);
   void setFrame(uint8_t b);
   void displayFrame(uint8_t frame);
 


### PR DESCRIPTION
`bool Adafruit_IS31FL3731::begin()` does not match prototype `boolean begin(uint8_t addr = ISSI_ADDR_DEFAULT);`. While this may not be an issue for Arduino boards with following typedef `typedef bool boolean;` it causes some trouble on Arduino ESP8266 2.5.0 core where `typedef uint8_t boolean;`.
Apperently it has been fixed [recently](https://github.com/esp8266/Arduino/pull/5693/files) in ESP8266.

Also Arduino advises to use [bool instead of boolean](https://www.arduino.cc/reference/en/language/variables/data-types/boolean/) not to mention that prototype should match the function definition.