### PR TITLE
 Added support for Pimoroni 11x7 matrix

### DIFF
--- a/Adafruit_IS31FL3731.cpp
+++ b/Adafruit_IS31FL3731.cpp
@@ -53,6 +53,15 @@ bool Adafruit_IS31FL3731::begin(uint8_t addr, TwoWire *theWire) {
     return false;
   }
 
+  //prevent flickering of screen when powered
+  for(int16_t xx=0; xx<15;xx++)
+  {
+	  for(int16_t yy=0;yy<8;yy++)
+	  {
+		  drawPixel(xx,yy,(int16_t)0x00);
+	  }
+  }
+
   _i2c_dev->setSpeed(400000);
   _frame = 0;
 

--- a/Adafruit_IS31FL3731.cpp
+++ b/Adafruit_IS31FL3731.cpp
@@ -27,6 +27,13 @@ Adafruit_IS31FL3731::Adafruit_IS31FL3731(uint8_t width, uint8_t height)
 /**************************************************************************/
 Adafruit_IS31FL3731_Wing::Adafruit_IS31FL3731_Wing(void)
     : Adafruit_IS31FL3731(15, 7) {}
+/**************************************************************************/
+/*!
+    @brief Constructor for Pimoroni version (11x7 LEDs)
+*/
+/**************************************************************************/
+Adafruit_IS31FL3731_11x7::Adafruit_IS31FL3731_11x7(void)
+    : Adafruit_IS31FL3731(11, 7) {}
 
 /**************************************************************************/
 /*!
@@ -150,6 +157,40 @@ void Adafruit_IS31FL3731_Wing::drawPixel(int16_t x, int16_t y, uint16_t color) {
   if (color > 255)
     color = 255; // PWM 8bit max
 
+  setLEDPWM(x + y * 16, color, _frame);
+  return;
+}
+
+
+void Adafruit_IS31FL3731_11x7::drawPixel(int16_t x, int16_t y, uint16_t color) {
+  // check rotation, move pixel around if necessary
+  switch (getRotation()) {
+  case 1:
+    _swap_int16_t(x, y);
+    x = 16 - x - 1;
+    break;
+  case 2:
+    x = 16 - x - 1;
+    y = 9 - y - 1;
+    break;
+  case 3:
+    _swap_int16_t(x, y);
+    y = 9 - y - 1;
+    break;
+  }
+
+  // if ((x < 0) || (x >= 16))
+  //   return;
+  // if ((y < 0) || (y >= 9))
+  //   return;
+  if (color > 255)
+    color = 255; // PWM 8bit max
+//added jack
+    if (y>5) {
+      x = x+8;
+      y = y-6;
+     }
+//added jack end
   setLEDPWM(x + y * 16, color, _frame);
   return;
 }

--- a/Adafruit_IS31FL3731.h
+++ b/Adafruit_IS31FL3731.h
@@ -5,7 +5,7 @@
 #include <Adafruit_I2CDevice.h>
 #include <Arduino.h>
 
-#define ISSI_ADDR_DEFAULT 0x75
+#define ISSI_ADDR_DEFAULT 0x74
 
 #define ISSI_REG_CONFIG 0x00
 #define ISSI_REG_CONFIG_PICTUREMODE 0x00

--- a/Adafruit_IS31FL3731.h
+++ b/Adafruit_IS31FL3731.h
@@ -5,7 +5,7 @@
 #include <Adafruit_I2CDevice.h>
 #include <Arduino.h>
 
-#define ISSI_ADDR_DEFAULT 0x74
+#define ISSI_ADDR_DEFAULT 0x75
 
 #define ISSI_REG_CONFIG 0x00
 #define ISSI_REG_CONFIG_PICTUREMODE 0x00
@@ -59,6 +59,18 @@ private:
 class Adafruit_IS31FL3731_Wing : public Adafruit_IS31FL3731 {
 public:
   Adafruit_IS31FL3731_Wing(void);
+  void drawPixel(int16_t x, int16_t y, uint16_t color);
+};
+
+/**************************************************************************/
+/*!
+    @brief Constructor for Pimoroni 11x7 IS31FL3731 version
+*/
+/**************************************************************************/
+
+class Adafruit_IS31FL3731_11x7 : public Adafruit_IS31FL3731 {
+public:
+  Adafruit_IS31FL3731_11x7(void);
   void drawPixel(int16_t x, int16_t y, uint16_t color);
 };
 


### PR DESCRIPTION
Added support for Pimoroni 11x7 matrix.
The address of Pimoroni 11x7 matrix (which is 0x75) should manually be put in the .h file for the Pimoroni 11x7 matrix to work properly